### PR TITLE
[Dagny] Fix GitHub issue #8: Add subscription enforcement to API rou...

### DIFF
--- a/src/app/api/events/route.ts
+++ b/src/app/api/events/route.ts
@@ -1,7 +1,15 @@
+/**
+ * Event API - Create and List Events
+ *
+ * GET /api/events?organizationId=xxx - List events for organization
+ * POST /api/events - Create new event
+ */
+
 import { NextResponse } from "next/server";
 import { auth } from "@clerk/nextjs/server";
 import { prisma } from "@/lib/db";
 import { z } from "zod";
+import { canCreateEvent } from "@/lib/stripe/subscription-service";
 
 // Validation schema for creating events
 const createEventSchema = z.object({
@@ -108,6 +116,15 @@ export async function POST(req: Request) {
 
     if (!member) {
       return NextResponse.json({ error: "Not a member" }, { status: 403 });
+    }
+
+    // Check subscription limits
+    const canCreate = await canCreateEvent(organizationId);
+    if (!canCreate) {
+      return NextResponse.json(
+        { error: "Event limit reached for your subscription tier" },
+        { status: 403 }
+      );
     }
 
     // Create the event

--- a/src/app/api/oauth/facebook/route.ts
+++ b/src/app/api/oauth/facebook/route.ts
@@ -13,6 +13,7 @@ import {
   generateOAuthState,
   buildAuthorizationUrl,
 } from '@/lib/platforms/oauth-config';
+import { canConnectPlatform } from "@/lib/stripe/subscription-service";
 
 export async function GET(request: Request) {
   try {
@@ -44,6 +45,15 @@ export async function GET(request: Request) {
     if (!membership) {
       return NextResponse.json(
         { error: 'Not authorized to manage this organization' },
+        { status: 403 }
+      );
+    }
+
+    // Check subscription limits
+    const canConnect = await canConnectPlatform(organizationId);
+    if (!canConnect) {
+      return NextResponse.json(
+        { error: 'Platform connection limit reached for your subscription tier' },
         { status: 403 }
       );
     }

--- a/src/app/api/oauth/linkedin/route.ts
+++ b/src/app/api/oauth/linkedin/route.ts
@@ -13,6 +13,7 @@ import {
   generateOAuthState,
   buildAuthorizationUrl,
 } from '@/lib/platforms/oauth-config';
+import { canConnectPlatform } from "@/lib/stripe/subscription-service";
 
 export async function GET(request: Request) {
   try {
@@ -44,6 +45,15 @@ export async function GET(request: Request) {
     if (!membership) {
       return NextResponse.json(
         { error: 'Not authorized to manage this organization' },
+        { status: 403 }
+      );
+    }
+
+    // Check subscription limits
+    const canConnect = await canConnectPlatform(organizationId);
+    if (!canConnect) {
+      return NextResponse.json(
+        { error: 'Platform connection limit reached for your subscription tier' },
         { status: 403 }
       );
     }

--- a/src/app/api/oauth/zoom/route.ts
+++ b/src/app/api/oauth/zoom/route.ts
@@ -13,6 +13,7 @@ import {
   generateOAuthState,
   buildAuthorizationUrl,
 } from '@/lib/platforms/oauth-config';
+import { canConnectPlatform } from "@/lib/stripe/subscription-service";
 
 export async function GET(request: Request) {
   try {
@@ -44,6 +45,15 @@ export async function GET(request: Request) {
     if (!membership) {
       return NextResponse.json(
         { error: 'Not authorized to manage this organization' },
+        { status: 403 }
+      );
+    }
+
+    // Check subscription limits
+    const canConnect = await canConnectPlatform(organizationId);
+    if (!canConnect) {
+      return NextResponse.json(
+        { error: 'Platform connection limit reached for your subscription tier' },
         { status: 403 }
       );
     }


### PR DESCRIPTION
## Autonomous Coding Task

Fix GitHub issue #8: Add subscription enforcement to API routes.

Wire the existing subscription enforcement functions into the API routes.

src/lib/stripe/subscription-service.ts exports:
- canCreateEvent(orgId: string): Promise<boolean>
- canConnectPlatform(orgId: string): Promise<boolean>

They return a simple boolean (true = allowed, false = denied).

Changes needed:
1. In src/app/api/events/route.ts POST handler: after the membership check, call canCreateEvent(organizationId). If it returns false, return NextResponse.json({ error: "Event limit reached for your subscription tier" }, { status: 403 })
2. In src/app/api/oauth/facebook/route.ts: after membership check, call canConnectPlatform(organizationId). If false, return 403 with "Platform connection limit reached".
3. In src/app/api/oauth/linkedin/route.ts: same as Facebook.
4. In src/app/api/oauth/zoom/route.ts: same as Facebook.

Import from "@/lib/stripe/subscription-service".

---
*Generated by Dagny Taggart via Aider + devstral (local)*
*Tool calls: 1 | Cost: $0.0000*